### PR TITLE
Re-read partition table (#430)

### DIFF
--- a/install-sd.sh
+++ b/install-sd.sh
@@ -701,6 +701,15 @@ function install_clear() {
   debug "Flushing file system buffers"
   sudo sync
 
+  # If partition's boundaries changed, sync may not be sufficient.
+  if sudo which partprobe &> /dev/null; then
+    debug "Re-reading partition table of ${opt_sdcardpath} (partprobe)"
+    sudo partprobe "${opt_sdcardpath}"
+  else
+    # Often not necessary so we continue and test our luck with mount
+    debug "Warning : partprobe not available."
+  fi
+
   mkdir -p "${files_path}" "${olinux_mountpoint}"
 
   debug "Mounting ${partition1} on ${olinux_mountpoint}"


### PR DESCRIPTION
If the first partition didn't exist or didn't have the same
boundaries, sync may not be enough.
However most often, it is unnecessary and, when it is, mount will
catch it so we try to continue if partprobe is not available.

https://dev.yunohost.org/issues/430
