### PR TITLE
Patch services.yml after flashing the image to work around install deadlock

### DIFF
--- a/install-sd.sh
+++ b/install-sd.sh
@@ -704,7 +704,7 @@ function patch_servicesyml() {
     if ! grep -q "need_lock" "${servicesyml}";
     then
         info "Patching services.yml"
-        sed -i "s/yunohost-firewall:/yunohost-firewall:\n  need_lock: true/g" ${servicesyml}
+        sed -i "s/yunohost-firewall:/yunohost-firewall:\n   need_lock: true/g" ${servicesyml}
     fi
 } 
 

--- a/install-sd.sh
+++ b/install-sd.sh
@@ -699,6 +699,15 @@ function replace_hypercube_sh() {
   sudo sync
 }
 
+function patch_servicesyml() {
+    local servicesyml="${olinux_mountpoint}/etc/yunohost/services.yml"
+    if ! grep -q "need_lock" "${servicesyml}";
+    then
+        info "Patching services.yml"
+        sed -i "s/yunohost-firewall:/yunohost-firewall:\n  need_lock: true/g" ${servicesyml}
+    fi
+} 
+
 ########################
 ### GLOBAL VARIABLES ###
 ########################
@@ -804,6 +813,8 @@ else
   info "Installing SD card (this could take a few minutes)"
   install_clear
 fi
+
+patch_servicesyml
 
 if [ ! -z "${hypercube_path}" ]; then
   info "Copying HyperCube file"


### PR DESCRIPTION
## Problem

It was reported on the mailing-list that there's currently an issue with the install. The install get stuck during the postinstall where it attempts to start the firewall.

## Explanation

The lock system of YunoHost was recently changed and we had a few complicated issue with that. Basically systemctl makes things not trivial to know which process launched the start/stop/restart/... (the PPID is 1), which complicates the lock handling.

Anyway, with respect to the firewall everything should be fine as long as a new line in `/etc/yunohost/services.yml`, `need_lock:true` is present for the yunohost-firewall service.

But, since the current Internet Cube images are not up to date, yunohost packages get upgraded during the install process. Naively, this shouldn't bring any trouble... but it turns out that the `/etc/yunohost/services.yml` file is not properly upgraded in that case (it's a weird situation for the package, because it's an upgrade in between the pre-installation and post-installation, and not handled correctly).

So basically `services.yml` is not updated properly, therefore the lock is not given/taken to/by the `systemctl yunohost-firewall start`, and the Cube gets stuck

## Solution

There are several possible solution for this, such as upgrading the Cube images, or fixing the upgrade process in YunoHost. But the process is a bit complicated / heavy and takes time.

Instead, a simple (dirty?) hack is to add the proper line in `services.yml` after flashing the image, similarly to the way the hypercube is added.

Hence the proposed patch :wink: 
