### PR TITLE
Update repo.labriqueinter.net infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ List of work documents:
 * https://pad.ilico.org/p/hardware_brique
 * http://pad.aquilenet.fr/p/LaBrique
 
-**[BUG REPORTS SHOULD BE OPEN HERE](https://dev.yunohost.org)**
+**[BUG REPORTS SHOULD BE OPEN HERE](https://github.com/labriqueinternet/labriqueinter.net/issues)**

--- a/en.html
+++ b/en.html
@@ -129,7 +129,7 @@
         <li>IRC: <a href='http://irc.lc/geeknode/labriqueinter.net/'>#labriqueinter.net</a> sur irc.geeknode.org</li>
         <li>Twitter: <a href="https://twitter.com/une_brique">@Une_brique</a> (rarely used)</li>
         <li>GitHub: <a href="https://github.com/labriqueinternet">labriqueinternet</a></li>
-        <li>BugTracker : <a href="https://dev.yunohost.org/">dev.yunohost.org</a></li>
+        <li>BugTracker : <a href="https://github.com/labriqueinternet/labriqueinter.net/issues">on GitHub</a></li>
         <li>Wiki : <a href="https://wiki.internetcu.be/">wiki.internetcu.be</a></li>
         <li>Press : <a href="https://github.com/labriqueinternet/labriqueinter.net/blob/master/PRESS.md">a simple list of press release about the cube</a></li>
         <li>Monthly meeting the second monday of each month : <a href="https://wiki.ldn-fai.net/wiki/Mumble">wiki.ldn-fai.net/wiki/Mumble</a></li>

--- a/hypercube/css/hypercube.css
+++ b/hypercube/css/hypercube.css
@@ -1,7 +1,7 @@
 /* HyperCube Service for the Internet Cube Project
  * Copyright (C) 2016 Julien Vaubourg <julien@vaubourg.com>
- * Contribute at https://github.com/labriqueinternet/labriqueinter.net/tree/master/hypercube
- * Report issues at https://dev.yunohost.org/projects/la-brique-internet/issues
+ * Contribute at https://github.com/labriqueinternet/labriqueinter.net
+ * Report issues at https://github.com/labriqueinternet/labriqueinter.net/issues
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/hypercube/downloads/hypercube-debug-page-detection.html
+++ b/hypercube/downloads/hypercube-debug-page-detection.html
@@ -7,8 +7,8 @@
 <!--
  HyperCube Service for the Internet Cube Project
  Copyright (C) 2017 Julien Vaubourg <julien@vaubourg.com>
- Contribute at https://github.com/labriqueinternet/labriqueinter.net/tree/master/hypercube
- Report issues at https://dev.yunohost.org/projects/la-brique-internet/issues
+ Contribute at https://github.com/labriqueinternet/labriqueinter.net/
+ Report issues at https://github.com/labriqueinternet/labriqueinter.net/issues
  
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by

--- a/hypercube/index.html
+++ b/hypercube/index.html
@@ -21,9 +21,9 @@
 <!--
  HyperCube Service for the Internet Cube Project
  Copyright (C) 2016 Julien Vaubourg <julien@vaubourg.com>
- Contribute at https://github.com/labriqueinternet/labriqueinter.net/tree/master/hypercube
- Report issues at https://dev.yunohost.org/projects/la-brique-internet/issues
- 
+ Contribute at https://github.com/labriqueinternet/labriqueinter.net
+ Report issues at https://github.com/labriqueinternet/labriqueinter.net/issues
+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as published by
  the Free Software Foundation, either version 3 of the License, or

--- a/hypercube/js/hypercube.js
+++ b/hypercube/js/hypercube.js
@@ -1,7 +1,7 @@
 /* HyperCube Service for the Internet Cube Project
  * Copyright (C) 2016 Julien Vaubourg <julien@vaubourg.com>
- * Contribute at https://github.com/labriqueinternet/labriqueinter.net/tree/master/hypercube
- * Report issues at https://dev.yunohost.org/projects/la-brique-internet/issues
+ * Contribute at https://github.com/labriqueinternet/labriqueinter.net/
+ * Report issues at https://github.com/labriqueinternet/labriqueinter.net/issues
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
         <li>IRC : <a href='http://irc.lc/geeknode/labriqueinter.net/'>#labriqueinter.net</a> sur irc.geeknode.org</li>
         <li>Twitter : <a href="https://twitter.com/une_brique">@Une_brique</a> (peu utilisé)</li>
         <li>GitHub : <a href="https://github.com/labriqueinternet">labriqueinternet</a></li>
-        <li>Rapports de bug : <a href="https://dev.yunohost.org/">dev.yunohost.org</a></li>
+        <li>Rapports de bug : <a href="https://github.com/labriqueinternet/labriqueinter.net/issues">sur GitHub</a></li>
         <li>Wiki : <a href="https://wiki.labriqueinter.net/">wiki.labriqueinter.net</a></li>
         <li>Communication : <a href="https://github.com/labriqueinternet/labriqueinter.net/blob/master/PRESS.md">une simple liste des apparitions de la brique</a></li>
         <li>Réunion Mensuelle le deuxième lundi de chaque mois sur Mumble : <a href="https://wiki.ldn-fai.net/wiki/Mumble">wiki.ldn-fai.net/wiki/Mumble</a></li>

--- a/repo_nginx_fancyindex/footer.html
+++ b/repo_nginx_fancyindex/footer.html
@@ -19,15 +19,7 @@
     <section id="guide-chiffrement">
       <h2><span>Guide</span> express (avec chiffrement)</h2>
 
-      <p>Pour encore plus de protection de vos données, le système de fichiers de votre Brique peut être chiffré (images <em>encryptedfs</em>).</p>
-
-      <p>La partition devra être déchiffrée à chaque redémarrage de la Brique. Il sera possible de procéder au déchiffrement à distance, grâce à une interface web accessible en HTTPS. Vous devrez alors utiliser l'adresse IP publique de votre FAI (directement en IPv6, ou en IPv4 avec de la redirection de ports sur votre box). </p>
-
-      <p>Il suffit de télécharger le <a href="https://repo.labriqueinter.net/install-sd.sh">SD Card Installer</a>, et l'exécuter avec l'option <em>-e</em> (ajouter <em>-2</em> à la fin pour une LIME2</em>, ou <em>-h</em> pour voir les autres options) :</p>
-
-      <pre>% bash install-sd.sh -e</pre>
-
-      <p>Pour l'accès SSH et la post-installation de YunoHost, voir la section <em>Post-installation</em> ci-dessous.</p>
+      <p>La création de brique utilisant un système de fichier chiffré n'est plus supportée pour le moment. Contacter l'équipe de développement si vous souhaitez aider sur ce sujet.</p>
     </section>
 
     <section id="post-installation">
@@ -38,9 +30,9 @@
 
       <p>Une fois la Brique localisée, connectez-vous par SSH sur le port 22 :</p>
 
-      <pre>root:olinux</pre>
+      <pre>root:yunohost</pre>
 
-      <p><strong>Note :</strong> S'il n'y a qu'une seule Brique sur votre réseau, vous pouvez aussi directement utiliser <code>ssh root@fe80::42:babe%wlan0</code> (en remplaçant <em>wlan0</em> par l'interface réseau que vous utilisez sur votre ordinateur).
+      <p><strong>Note :</strong> S'il n'y a qu'une seule Brique sur votre réseau, vous pouvez aussi directement utiliser <code>ssh root@fe80::42:acab%eth0</code> (en remplaçant <em>eth0</em> par l'interface réseau que vous utilisez sur votre ordinateur).
 
       <p>La première chose à faire est de mettre à jour Debian/YunoHost :</p>
 
@@ -48,9 +40,9 @@
 
       <p>Vous pouvez maintenant faire la <a href="https://yunohost.org/#/postinstall_fr">post-installation</a>.
 
-      <p>Ajoutez ensuite la liste des apps dédiées à la Brique Internet à YunoHost :</p>
+      <p>Ajoutez ensuite la liste des apps community à YunoHost :</p>
 
-      <pre>% yunohost app fetchlist -n labriqueinternet -u https://labriqueinter.net/apps/labriqueinternet.json</pre>
+      <pre>% yunohost app fetchlist -n community -u https://app.yunohost.org/community.json</pre>
 
       <p>À partir de l'administration web de YunoHost, vous pouvez désormais installer les apps <em>VPN Client</em> et <em>Wifi Hotspot</em>, puis aller les configurer.
     </section>

--- a/repo_nginx_fancyindex/footer.html
+++ b/repo_nginx_fancyindex/footer.html
@@ -19,7 +19,7 @@
     <section id="guide-chiffrement">
       <h2><span>Guide</span> express (avec chiffrement)</h2>
 
-      <p>La création de brique utilisant un système de fichier chiffré n'est plus supportée pour le moment. Contacter l'équipe de développement si vous souhaitez aider sur ce sujet.</p>
+      <p>La création d'une Brique utilisant un système de fichier chiffré n'est plus supportée pour le moment. Contacter l'équipe de développement si vous souhaitez aider sur ce sujet.</p>
     </section>
 
     <section id="post-installation">
@@ -56,9 +56,9 @@
 
         <pre>% bash install-sd.sh -y fichier_hypercube.hyp</pre>
 
-        <p>Si le fichier n'a pas été fourni via le <code>install-sh.sh</code>, il est plus tard possible de brancher une clef USB (formattée en NTFS ou FAT32) sur la brique, contenant le fichier. L'installation via l'hypercube sera alors lancée automatiquement.</p>
+        <p>Si le fichier n'a pas été fourni via le <code>install-sh.sh</code>, il est plus tard possible de brancher une clef USB (formattée en NTFS ou FAT32) sur la Brique, contenant le fichier. L'installation via l'hypercube sera alors lancée automatiquement.</p>
 
-        <p>Le déroulement de l'installation de la brique peut être suivi via l'interface web accessible à <code>https://192.168.x.y:2468/</code></p>
+        <p>Le déroulement de l'installation de la Brique peut être suivi via l'interface web accessible à <code>https://192.168.x.y:2468/</code></p>
 
         <p>Ou bien il est possible de détecter automatiquement l'interface de debug sur le réseau à l'aide de <a href="https://repo.internetcu.be/tools/hypercube-debug-page-detection.html">cette page</a>.</p>
     </section>

--- a/repo_nginx_fancyindex/footer.html
+++ b/repo_nginx_fancyindex/footer.html
@@ -46,6 +46,22 @@
 
       <p>À partir de l'administration web de YunoHost, vous pouvez désormais installer les apps <em>VPN Client</em> et <em>Wifi Hotspot</em>, puis aller les configurer.
     </section>
+
+    <section id="install-with-hypercube">
+        <h2><span>Hyper</span>cube</h2>
+
+        <p>La méthode d'installation recommandée consiste à utiliser un fichier hypercube généré via <a href="https://install.labriqueinter.net/">cette page</a>.</p>
+
+        <p>Le fichier hypercube peut être fourni au script <code>install-sd.sh</code> de la manière suivante :</p>
+
+        <pre>% bash install-sd.sh -y fichier_hypercube.hyp</pre>
+
+        <p>Si le fichier n'a pas été fourni via le <code>install-sh.sh</code>, il est plus tard possible de brancher une clef USB (formattée en NTFS ou FAT32) sur la brique, contenant le fichier. L'installation via l'hypercube sera alors lancée automatiquement.</p>
+
+        <p>Le déroulement de l'installation de la brique peut être suivi via l'interface web accessible à <code>https://192.168.x.y:2468/</code></p>
+
+        <p>Ou bien il est possible de détecter automatiquement l'interface de debug sur le réseau à l'aide de <a href="https://repo.internetcu.be/tools/hypercube-debug-page-detection.html">cette page</a>.</p>
+    </section>
   </main>
 
   <footer>

--- a/repo_nginx_fancyindex/footer.html
+++ b/repo_nginx_fancyindex/footer.html
@@ -54,7 +54,7 @@
 
         <p>Le fichier hypercube peut être fourni au script <code>install-sd.sh</code> de la manière suivante :</p>
 
-        <pre>% bash install-sd.sh -y fichier_hypercube.hyp</pre>
+        <pre>% bash install-sd.sh -y install.hypercube</pre>
 
         <p>Si le fichier n'a pas été fourni via le <code>install-sh.sh</code>, il est plus tard possible de brancher une clef USB (formattée en NTFS ou FAT32) sur la Brique, contenant le fichier. L'installation via l'hypercube sera alors lancée automatiquement.</p>
 

--- a/repo_nginx_fancyindex/footer_en.html
+++ b/repo_nginx_fancyindex/footer_en.html
@@ -47,6 +47,22 @@
 
       <p>From the YunoHost web administration, you can now install the <em>VPN Client</em> and <em>Wifi Hotspot</em> apps, then configure them.</p>
     </section>
+
+    <section id="install-with-hypercube">
+        <h2><span>Hyper</span>cube</h2>
+
+        <p>The recommended installation method consists in using an hypercube file generated from <a href="https://install.labriqueinter.net/">this page</a>.</p>
+
+        <p>The hypercube file can be fed to the <code>install-sd.sh</code> script in the following way:</p>
+
+        <pre>% bash install-sd.sh -y hypercube_file.hyp</pre>
+
+        <p>If the file was not fed to the <code>install-sh.sh</code>, it is still possible to plug an USB key (formated in NTFS or FAT32) on the cube with the file on it to trigger the install automatically.</p>
+
+        <p>The installation procedure can be followed from the web interface accessible at <code>https://192.168.x.y:2468/</code></p>
+
+        <p>Or it is possible to detect automatically the debug interface available on the local network using <a href="https://repo.internetcu.be/tools/hypercube-debug-page-detection.html">this tool</a>.</p>
+    </section>
   </main>
 
   <footer>

--- a/repo_nginx_fancyindex/footer_en.html
+++ b/repo_nginx_fancyindex/footer_en.html
@@ -55,7 +55,7 @@
 
         <p>The hypercube file can be fed to the <code>install-sd.sh</code> script in the following way:</p>
 
-        <pre>% bash install-sd.sh -y hypercube_file.hyp</pre>
+        <pre>% bash install-sd.sh -y install.hypercube</pre>
 
         <p>If the file was not fed to the <code>install-sh.sh</code>, it is still possible to plug an USB key (formated in NTFS or FAT32) on the cube with the file on it to trigger the install automatically.</p>
 

--- a/repo_nginx_fancyindex/footer_en.html
+++ b/repo_nginx_fancyindex/footer_en.html
@@ -19,15 +19,7 @@
     <section id="guide-encrypted">
       <h2><span>Quick</span> Guide (encrypted)</h2>
 
-      <p>For even further privacy, the root file system of your Cube can be encrypted (images <em>encryptedfs</em>).</p>
-
-      <p>The hard drive will have to be unlocked each time your Cube is rebooting. You will be able to remotely unlock the hard drive by accessing to your Cube with HTTPS. For that, you will have to use the public IPv4 from your ISP, with a correctly configured port-forwarding on your router (or directly IPv6 if your are lucky).</p>
-
-      <p>Download the <a href="https://repo.internetcu.be/install-sd.sh">SD Card Installer</a>, and just run it with <em>-e</em> (add <em>-2</em> at the end for a LIME2</em>, or <em>-h</em> to see other options):</p>
-
-      <pre>% bash install-sd.sh -e</pre>
-
-      <p>For the SSH access and the YunoHost post-installation, see the <em>Post-Installation</em> section below.</p>
+      <p>The creation of cubes with an encrypted filesystem is currently not supported anymore. Contact the development team if you wish to help on this topic.</p>
     </section>
 
     <section id="post-installation">
@@ -39,9 +31,9 @@
 
       <p>Once your Cube found, connect with SSH on port 22:</p>
 
-      <pre>root:olinux</pre>
+      <pre>root:yunohost</pre>
 
-      <p><strong>Note:</strong> If there is only one Cube on your network, you can also directly use <code>ssh root@fe80::42:babe%wlan0</code> (replacing <em>wlan0</em> by the network device you use on your computer).
+      <p><strong>Note:</strong> If there is only one Cube on your network, you can also directly use <code>ssh root@fe80::42:acab%eth0</code> (replacing <em>eth0</em> by the network device you use on your computer).
 
       <p>The first thing to do is upgrading Debian/Yunohost:</p>
 
@@ -49,9 +41,9 @@
 
       <p>You can now do the YunoHost <a href="https://yunohost.org/#/postinstall_en">post-installation</a>.
 
-      <p>Then, add the list of apps dedicated to the Internet Cube to YunoHost:</p>
+      <p>Then, add the list of community apps to YunoHost:</p>
 
-      <pre>% yunohost app fetchlist -n labriqueinternet -u https://labriqueinter.net/apps/labriqueinternet.json</pre>
+      <pre>% yunohost app fetchlist -n community -u https://app.yunohost.org/community.json</pre>
 
       <p>From the YunoHost web administration, you can now install the <em>VPN Client</em> and <em>Wifi Hotspot</em> apps, then configure them.</p>
     </section>


### PR DESCRIPTION
Some info are outdated on repo.labriqueinter.net

I also updated the link to the bugtracker since dev.yunohost.org is dead now